### PR TITLE
Fixed issue on iPad when multitasking

### DIFF
--- a/Pod/Classes/SwiftPhotoGallery.swift
+++ b/Pod/Classes/SwiftPhotoGallery.swift
@@ -443,12 +443,12 @@ extension SwiftPhotoGallery: UICollectionViewDataSource {
 
     @objc public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         guard isRevolvingCarouselEnabled else { return CGSize.zero }
-        return CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+        return view.frame.size
     }
 
     @objc public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         guard isRevolvingCarouselEnabled else { return CGSize.zero }
-        return CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+        return view.frame.size
     }
 }
 


### PR DESCRIPTION
When SwiftPhotoGallery runs on iPad with multitasking is enabled, image is not placed in centre.
Because the size header and footer section is set to Screen Size which doesn't equal view size.